### PR TITLE
Remove unnecessary `use` clauses

### DIFF
--- a/tests/AdsBibcodeTest.php
+++ b/tests/AdsBibcodeTest.php
@@ -1,7 +1,5 @@
 <?php
-namespace Altmetric;
-
-use Altmetric\Identifiers\AdsBibcode;
+namespace Altmetric\Identifiers;
 
 class AdsBibcodeTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -1,8 +1,6 @@
 <?php
 namespace Altmetric\Identifiers;
 
-use Altmetric\Identifiers\Isbn;
-
 class IsbnTest extends \PHPUnit_Framework_TestCase
 {
     public function testExtractsIsbn13s()

--- a/tests/NationalClinicalTrialIdTest.php
+++ b/tests/NationalClinicalTrialIdTest.php
@@ -1,7 +1,5 @@
 <?php
-namespace Altmetric;
-
-use Altmetric\Identifiers\NationalClinicalTrialId;
+namespace Altmetric\Identifiers;
 
 class NationalClinicalTrialIdTest extends \PHPUnit_Framework_TestCase
 {

--- a/tests/OrcidIdTest.php
+++ b/tests/OrcidIdTest.php
@@ -1,7 +1,5 @@
 <?php
-namespace Altmetric;
-
-use Altmetric\Identifiers\OrcidId;
+namespace Altmetric\Identifiers;
 
 class OrcidIdTest extends \PHPUnit_Framework_TestCase
 {


### PR DESCRIPTION
The `use` clauses are not needed as long as we are in the same namespace.
You could also only use the `use` clauses and drop the `namespace` part instead.