### PR TITLE
Support ISBNs separated with spaces

### DIFF
--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -10,14 +10,14 @@ class Isbn
 
     private static function extractIsbn13s($str)
     {
-        preg_match_all('/\b97[89]\d{10}\b/', str_replace('-', '', $str), $matches);
+        preg_match_all('/\b97[89]\d{10}\b/', preg_replace('/(?<=\d)[- ](?=\d)/', '', $str), $matches);
 
         return array_filter($matches[0], [__CLASS__, 'isValidIsbn13']);
     }
 
     private static function extractIsbn10s($str)
     {
-        preg_match_all('/\b\d{9}[\dX]\b/i', str_replace('-', '', $str), $matches);
+        preg_match_all('/\b\d{9}[\dX]\b/i', preg_replace('/(?<=\d)[- ](?=[\dX])/i', '', $str), $matches);
 
         return array_map(
             [__CLASS__, 'convertIsbn10ToIsbn13'],

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -13,6 +13,26 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['9780805069099'], Isbn::extract('978-0-80-506909-9'));
     }
 
+    public function testExtractsIsbn13sWithSpaces()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('978 0 80 506909 9'));
+    }
+
+    public function testExtractsIsbn13sPrecededByText()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('I like 978 0 80 506909 9'));
+    }
+
+    public function testExtractsIsbn13sSucceededByText()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('978 0 80 506909 9 is great'));
+    }
+
+    public function testExtractsIsbn13sOnNewLines()
+    {
+        $this->assertEquals(['9780805069099', '9780671879198'], Isbn::extract("978-0-80-506909-9\n978-0-67-187919-8"));
+    }
+
     public function testDoesNotExtractInvalidIsbn13s()
     {
         $this->assertEmpty(Isbn::extract('9783319217280'));
@@ -21,6 +41,16 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     public function testConvertsValidIsbn10sToIsbn13s()
     {
         $this->assertEquals(['9780805069099'], Isbn::extract('0-8050-6909-7'));
+    }
+
+    public function testConvertsValidIsbn10sWithSpacesToIsbn13s()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('0 8050 6909 7'));
+    }
+
+    public function testConvertsValidIsbn10sWithSpacesAndXToIsbn13s()
+    {
+        $this->assertEquals(['9780805069952'], Isbn::extract('0 8050 6995 X'));
     }
 
     public function testConvertsValidIsbn10sWithXCheckDigitToIsbn13s()


### PR DESCRIPTION
As ISBNs can officially [0] be separated with spaces as well as hyphens, support the extraction of identifiers with spaces. Note that we are now stricter about removing hyphens so that it is only done between digits or an X check digit.

  [0]: https://www.isbn-international.org/content/what-isbn