### PR TITLE
Add support for ISBN-As when extracting DOIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ $isbns = Isbn::extract("ISBN: 9780805069099\nISBN: 2-7594-0269-X");
 //=> ['9780805069099', '9782759402694']
 ```
 
-Return an array of ISBN-13s from a given string. Will convert ISBN-10s to ISBN-13s automatically and return an empty array if no matches are found.
+Return an array of ISBN-13s from a given string. Will convert ISBN-As and ISBN-10s to ISBN-13s automatically and return an empty array if no matches are found.
 
 ### `public NationalClinicalTrialId::extract(string $str): array`
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The supported list is:
 
 * [ADS Bibcodes](http://adsdoc.harvard.edu/abs_doc/help_pages/bibcodes.html);
 * [arXiv IDs](https://arxiv.org/help/arxiv_identifier);
-* [DOIs](https://www.doi.org/);
+* [DOIs](https://www.doi.org/) (including [ISBN-As](https://www.doi.org/factsheets/ISBN-A.html));
 * [Handles](https://en.wikipedia.org/wiki/Handle_System);
 * [ISBNs](https://en.wikipedia.org/wiki/International_Standard_Book_Number);
 * [National Clinical Trial IDs](https://clinicaltrials.gov/);
@@ -61,7 +61,7 @@ $dois = Doi::extract('doi:10.1049/el.2013.3006')
 //=> ['10.1049/el.2013.3006']
 ```
 
-Return an array of DOIs from a given string. Will return an empty array if no matches are found.
+Return an array of DOIs (including [ISBN-As](https://www.doi.org/factsheets/ISBN-A.html)) from a given string. Will return an empty array if no matches are found.
 
 ### `public Handle::extract(string $str): array`
 

--- a/src/Doi.php
+++ b/src/Doi.php
@@ -5,7 +5,7 @@ class Doi
 {
     public static function extract($str)
     {
-        preg_match_all('/\b10\.\d{4,9}\/\S+\b/', $str, $matches);
+        preg_match_all('#\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)\b#', $str, $matches);
 
         return array_map('strtolower', $matches[0]);
     }

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -5,7 +5,19 @@ class Isbn
 {
     public static function extract($str)
     {
-        return self::extractIsbn13s($str) + self::extractIsbn10s($str);
+        return self::extractIsbnAs($str) + self::extractIsbn13s($str) + self::extractIsbn10s($str);
+    }
+
+    private static function extractIsbnAs($str)
+    {
+        preg_match_all('#(?<=10\.)97[89]\.\d{2,8}/\d{1,7}\b#', $str, $matches);
+
+        return self::extractIsbn13s(
+            implode(
+                PHP_EOL,
+                array_map([__CLASS__, 'convertIsbnAToIsbn13'], $matches[0])
+            )
+        );
     }
 
     private static function extractIsbn13s($str)
@@ -23,6 +35,11 @@ class Isbn
             [__CLASS__, 'convertIsbn10ToIsbn13'],
             array_filter($matches[0], [__CLASS__, 'isValidIsbn10'])
         );
+    }
+
+    private static function convertIsbnAToIsbn13($str)
+    {
+        return str_replace(['.', '/'], '', $str);
     }
 
     private static function isValidIsbn13($str)

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -8,6 +8,16 @@ class DoiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['10.1049/el.2013.3006'], Doi::extract('This is an example of DOI: 10.1049/el.2013.3006'));
     }
 
+    public function testExtractsIsbnAs()
+    {
+        $this->assertEquals(['10.978.8898392/315'], Doi::extract('http://dx.doi.org/10.978.8898392/315'));
+    }
+
+    public function testDoesNotExtractsInvalidIsbnAs()
+    {
+        $this->assertEmpty(Doi::extract('http://dx.doi.org/10.978.8898392/NotARealIsbnA'));
+    }
+
     public function testLowercasesDois()
     {
         $this->assertEquals(['10.1097/01.asw.0000443266.17665.19'], Doi::extract('10.1097/01.ASW.0000443266.17665.19'));

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -62,4 +62,14 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(Isbn::extract('0-8050-6909-X'));
     }
+
+    public function testExtractsIsbnAsFromDois()
+    {
+        $this->assertEquals(['9788898392315'], Isbn::extract('http://dx.doi.org/10.978.8898392/315'));
+    }
+
+    public function testDoesNotExtractInvalidIsbnAsFromDois()
+    {
+        $this->assertEmpty(Isbn::extract('http://dx.doi.org/10.978.8898392/316'));
+    }
 }


### PR DESCRIPTION
As the DOI system can be used to express ISBNs in the form of ISBN-As and this was not supported by our pattern matching, explicitly add support for ISBN-As when extracting DOIs.

See https://www.doi.org/factsheets/ISBN-A.html for more information about the format.