### PR TITLE
Support valid DOIs ending in punctuation

### DIFF
--- a/src/Doi.php
+++ b/src/Doi.php
@@ -47,6 +47,6 @@ EOT;
             return $doi;
         }
 
-        return preg_replace('/\p{P}+$/u', '', $doi);
+        return self::stripTrailingPunctuation(preg_replace('/\p{P}$/u', '', $doi));
     }
 }

--- a/src/Doi.php
+++ b/src/Doi.php
@@ -19,17 +19,19 @@ class Doi
         /       # Prefix/suffix divider
         \S+     # DOI suffix
     )
-}x
+}xu
 EOT;
-    const VALID_TRAILING_PUNCTUATION = <<<'EOT'
+    const VALID_ENDING = <<<'EOT'
 /
     (?:
-        \(.+\) # Balanced parentheses
+        \p{^P}  # Non-punctuation character
         |
-        2-\#   # Early Wiley DOI suffix
+        \(.+\)  # Balanced parentheses
+        |
+        2-\#    # Early Wiley DOI suffix
     )
     $
-/x
+/xu
 EOT;
 
     public static function extract($str)
@@ -41,10 +43,10 @@ EOT;
 
     private static function stripTrailingPunctuation($doi)
     {
-        if (!preg_match('/[[:punct:]]$/', $doi) || preg_match(self::VALID_TRAILING_PUNCTUATION, $doi)) {
+        if (preg_match(self::VALID_ENDING, $doi)) {
             return $doi;
         }
 
-        return preg_replace('/[[:punct:]]+$/', '', $doi);
+        return preg_replace('/\p{P}+$/u', '', $doi);
     }
 }

--- a/src/Doi.php
+++ b/src/Doi.php
@@ -38,7 +38,17 @@ EOT;
     {
         preg_match_all(self::PATTERN, strtolower($str), $matches);
 
-        return array_map([__CLASS__, 'stripTrailingPunctuation'], $matches[0]);
+        return array_filter(array_map([__CLASS__, 'stripTrailingPunctuation'], $matches[0]));
+    }
+
+    public static function extractOne($str)
+    {
+        preg_match(self::PATTERN, strtolower($str), $matches);
+        if (empty($matches)) {
+            return;
+        }
+
+        return self::stripTrailingPunctuation($matches[0]);
     }
 
     private static function stripTrailingPunctuation($doi)
@@ -47,6 +57,6 @@ EOT;
             return $doi;
         }
 
-        return self::stripTrailingPunctuation(preg_replace('/\p{P}$/u', '', $doi));
+        return self::extractOne(preg_replace('/\p{P}$/u', '', $doi));
     }
 }

--- a/src/Doi.php
+++ b/src/Doi.php
@@ -3,10 +3,48 @@ namespace Altmetric\Identifiers;
 
 class Doi
 {
+    const PATTERN = <<<'EOT'
+{
+    10 # Directory indicator (always 10)
+    \.
+    (?:
+        # ISBN-A
+        97[89]\. # ISBN (GS1) Bookland prefix
+        \d{2,8}  # ISBN registration group element and publisher prefix
+        /        # Prefix/suffix divider
+        \d{1,7}  # ISBN title enumerator and check digit
+        |
+        # DOI
+        \d{4,9} # Registrant code
+        /       # Prefix/suffix divider
+        \S+     # DOI suffix
+    )
+}x
+EOT;
+    const VALID_TRAILING_PUNCTUATION = <<<'EOT'
+/
+    (?:
+        \(.+\) # Balanced parentheses
+        |
+        2-\#   # Early Wiley DOI suffix
+    )
+    $
+/x
+EOT;
+
     public static function extract($str)
     {
-        preg_match_all('#\b10\.(?:97[89]\.\d{2,8}/\d{1,7}|\d{4,9}/\S+)\b#', $str, $matches);
+        preg_match_all(self::PATTERN, strtolower($str), $matches);
 
-        return array_map('strtolower', $matches[0]);
+        return array_map([__CLASS__, 'stripTrailingPunctuation'], $matches[0]);
+    }
+
+    private static function stripTrailingPunctuation($doi)
+    {
+        if (!preg_match('/[[:punct:]]$/', $doi) || preg_match(self::VALID_TRAILING_PUNCTUATION, $doi)) {
+            return $doi;
+        }
+
+        return preg_replace('/[[:punct:]]+$/', '', $doi);
     }
 }

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -62,7 +62,7 @@ class DoiTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             ['10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#'],
-            Doi::extract('This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#')
+            Doi::extract('This is an example of an old Wiley DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#')
         );
     }
 
@@ -70,7 +70,7 @@ class DoiTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             ['10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#'],
-            Doi::extract('This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#",')
+            Doi::extract('This is an example of an old Wiley DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#",')
         );
     }
 
@@ -104,5 +104,10 @@ class DoiTest extends \PHPUnit_Framework_TestCase
             ['10.1130/2013.2502'],
             Doi::extract('(This is an example of a DOI: 10.1130/2013.2502).",')
         );
+    }
+
+    public function testDoesNotExtractDoisWithPurelyPunctuationSuffixes()
+    {
+        $this->assertEmpty(Doi::extract('10.1130/!).",'));
     }
 }

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -58,11 +58,51 @@ class DoiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['10.1130/2013.2502'], Doi::extract('(This is an example of a DOI: 10.1130/2013.2502)'));
     }
 
-    public function testExtractsExoticDois()
+    public function testExtractsOldWileyDois()
     {
         $this->assertEquals(
             ['10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#'],
             Doi::extract('This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#')
+        );
+    }
+
+    public function testDiscardsTrailingPunctuationFromOldWileyDois()
+    {
+        $this->assertEquals(
+            ['10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#'],
+            Doi::extract('This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#",')
+        );
+    }
+
+    public function testDiscardsTrailingPunctuationAfterBalancedParentheses()
+    {
+        $this->assertEquals(
+            ['10.1130/2013.2502(04)'],
+            Doi::extract('This is an example of a DOI: 10.1130/2013.2502(04).')
+        );
+    }
+
+    public function testDiscardsContiguousTrailingPunctuationAfterBalancedParentheses()
+    {
+        $this->assertEquals(
+            ['10.1130/2013.2502(04)'],
+            Doi::extract('This is an example of a DOI: 10.1130/2013.2502(04).",')
+        );
+    }
+
+    public function testDiscardsTrailingUnicodePunctuationAfterBalancedParentheses()
+    {
+        $this->assertEquals(
+            ['10.1130/2013.2502(04)'],
+            Doi::extract('This is an example of a DOI: 10.1130/2013.2502(04)…",')
+        );
+    }
+
+    public function testDiscardsContiguousTrailingPunctuationAfterUnbalancedParentheses()
+    {
+        $this->assertEquals(
+            ['10.1130/2013.2502'],
+            Doi::extract('(This is an example of a DOI: 10.1130/2013.2502).",')
         );
     }
 }

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -43,6 +43,11 @@ class DoiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['10.1130/2013.2502'], Doi::extract('This is an example of a DOI: 10.1130/2013.2502...",'));
     }
 
+    public function testDiscardsTrailingUnicodePunctuation()
+    {
+        $this->assertEquals(['10.1130/2013.2502'], Doi::extract('This is an example of a DOI: 10.1130/2013.2502…'));
+    }
+
     public function testRetainsClosingParenthesesThatArePartOfTheDoi()
     {
         $this->assertEquals(['10.1130/2013.2502(04)'], Doi::extract('This is an example of a DOI: 10.1130/2013.2502(04)'));

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -8,6 +8,16 @@ class DoiTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['10.1049/el.2013.3006'], Doi::extract('This is an example of DOI: 10.1049/el.2013.3006'));
     }
 
+    public function testReturnsEmptyIfGivenNothing()
+    {
+        $this->assertEmpty(Doi::extract(null));
+    }
+
+    public function testExtractsDoisFromMiddlesOfStrings()
+    {
+        $this->assertEquals(['10.1049/el.2013.3006'], Doi::extract('This is an example of DOI: 10.1049/el.2013.3006 with trailing words'));
+    }
+
     public function testExtractsIsbnAs()
     {
         $this->assertEquals(['10.978.8898392/315'], Doi::extract('http://dx.doi.org/10.978.8898392/315'));
@@ -21,5 +31,33 @@ class DoiTest extends \PHPUnit_Framework_TestCase
     public function testLowercasesDois()
     {
         $this->assertEquals(['10.1097/01.asw.0000443266.17665.19'], Doi::extract('10.1097/01.ASW.0000443266.17665.19'));
+    }
+
+    public function testDiscardsTrailingPunctuation()
+    {
+        $this->assertEquals(['10.1130/2013.2502'], Doi::extract('This is an example of a DOI: 10.1130/2013.2502.'));
+    }
+
+    public function testDiscardsContiguousTrailingPunctuation()
+    {
+        $this->assertEquals(['10.1130/2013.2502'], Doi::extract('This is an example of a DOI: 10.1130/2013.2502...",'));
+    }
+
+    public function testRetainsClosingParenthesesThatArePartOfTheDoi()
+    {
+        $this->assertEquals(['10.1130/2013.2502(04)'], Doi::extract('This is an example of a DOI: 10.1130/2013.2502(04)'));
+    }
+
+    public function testDiscardsClosingParenthesesThatAreNotPartOfTheDoi()
+    {
+        $this->assertEquals(['10.1130/2013.2502'], Doi::extract('(This is an example of a DOI: 10.1130/2013.2502)'));
+    }
+
+    public function testExtractsExoticDois()
+    {
+        $this->assertEquals(
+            ['10.1002/(sici)1096-8644(199601)99:1<135::aid-ajpa8>3.0.co;2-#'],
+            Doi::extract('This is an example of an exotic DOI: 10.1002/(SICI)1096-8644(199601)99:1<135::AID-AJPA8>3.0.CO;2-#')
+        );
     }
 }


### PR DESCRIPTION
During some internal data clean-up work at @altmetric, we discovered DOIs that end with closing parentheses. These were being dropped by our extraction regular expression as we enforce a word boundary (which splits when a word character is followed by a non-word character such as a closing parenthesis).

By removing the strict word boundary, we can now pick up these closing parentheses and filter out any unwanted trailing punctuation in a second pass over the matches.

We do this by explicitly dropping the last character if it is punctuation but _not_ if the DOI ends in a single, balanced parenthetical group of characters or if it is an early Wiley DOI (which end in a certain sequence of punctuation).

This means that we can successfully extract valid DOIs such as 10.1002/0471221929.ch26(v) but not invalid ones such as 10.1007/978-3-319-12580-0).