### PR TITLE
Cleanup arXiv ID extraction

### DIFF
--- a/src/ArxivId.php
+++ b/src/ArxivId.php
@@ -3,6 +3,32 @@ namespace Altmetric\Identifiers;
 
 class ArxivId
 {
+    const POST_2007_PATTERN = <<<'EOT'
+{
+    (?<=^|\s|/) # Look-behind for the start of the string, whitespace or a forward slash
+    (?:arXiv:)? # Optional arXiv scheme
+    \d{4}       # YYMM (two-digit year and two-digit month number)
+    \.
+    \d{4,5}     # Zero-padded sequence number of 4- or 5-digits
+    (?:v\d+)?   # Literal v followed by version number of 1 or more digits
+    (?=$|\s)    # Look-ahead for end of string or whitespace
+}xiu
+EOT;
+    const PRE_2007_PATTERN = <<<'EOT'
+{
+    (?<=^|\s|/)       # Look-behind for the start of the string, whitespace or a forward slash
+    (?:arXiv:)?       # Optional arXiv scheme
+    [a-z-]+           # Archive (e.g. "math")
+    (?:\.[A-Z]{2})?   # Subject class (where applicable)
+    /
+    \d{2}             # Year
+    (?:0[1-9]|1[012]) # Month
+    \d{3}             # Number
+    (?:v\d+)?         # Literal v followed by version number of 1 or more digits
+    (?=$|\s)          # Look-ahead for end of string or whitespace
+}xiu
+EOT;
+
     public static function extract($str)
     {
         return self::extractPre2007ArxivIds($str) + self::extractPost2007ArxivIds($str);
@@ -10,14 +36,14 @@ class ArxivId
 
     private static function extractPost2007ArxivIds($str)
     {
-        preg_match_all('#(?<=^|\s|/)(?:arXiv:)?\d{4}\.\d{4,5}(?:v\d+)?(?=$|\s)#i', $str, $matches);
+        preg_match_all(self::POST_2007_PATTERN, $str, $matches);
 
         return array_map([__CLASS__, 'stripArxivScheme'], $matches[0]);
     }
 
     private static function extractPre2007ArxivIds($str)
     {
-        preg_match_all('#(?<=^|\s|/)(?:arXiv:)?[a-z-]+(?:\.[A-Z]{2})?/\d{2}(?:0[1-9]|1[012])\d{3}(?:v\d+)?(?=$|\s)#i', $str, $matches);
+        preg_match_all(self::PRE_2007_PATTERN, $str, $matches);
 
         return array_map([__CLASS__, 'stripArxivScheme'], $matches[0]);
     }

--- a/tests/ArxivIdTest.php
+++ b/tests/ArxivIdTest.php
@@ -8,6 +8,11 @@ class ArxivIdTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['math.GT/0309136'], ArxivId::extract('Example: math.GT/0309136'));
     }
 
+    public function testExtractsPre2007ArxivIdsEndingInUnicodeWhitespace()
+    {
+        $this->assertEquals(['math.GT/0309136'], ArxivId::extract('Example: math.GT/0309136 '));
+    }
+
     public function testExtractsPost2007UnversionedArxivIds()
     {
         $this->assertEquals(['0706.0001'], ArxivId::extract('Example: arXiv:0706.0001'));
@@ -18,8 +23,23 @@ class ArxivIdTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['1501.00001v2'], ArxivId::extract('Example: arXiv:1501.00001v2'));
     }
 
+    public function testExtractsPost2007ArxivIdsEndingInUnicodeWhitespace()
+    {
+        $this->assertEquals(['1501.00001v2'], ArxivId::extract('Example: arXiv:1501.00001v2 '));
+    }
+
     public function testDoesNotExtractArxivIdsFromDois()
     {
         $this->assertEmpty(ArxivId::extract("10.1049/el.2013.3006\n10.2310/7290.2014.00033"));
+    }
+
+    public function testExtractsPost2007ArxivIdsFromUrls()
+    {
+        $this->assertEquals(['1704.01279'], ArxivId::extract('https://arxiv.org/abs/1704.01279'));
+    }
+
+    public function testExtractsPre2007ArxivIdsFromUrls()
+    {
+        $this->assertEquals(['math/0309136'], ArxivId::extract('https://arxiv.org/abs/math/0309136'));
     }
 }


### PR DESCRIPTION
Expand the complicated arXiv ID regular expressions into extended format to improve maintenance and improve Unicode support.