### PR TITLE
Improve Unicode support across identifiers

### DIFF
--- a/src/AdsBibcode.php
+++ b/src/AdsBibcode.php
@@ -5,7 +5,7 @@ class AdsBibcode
 {
     public static function extract($str)
     {
-        preg_match_all('/\b\d{4}[a-z][0-9a-z&.]{14}\b/i', $str, $matches);
+        preg_match_all('/\b\d{4}[a-z][0-9a-z&.]{14}\b/ui', $str, $matches);
 
         return $matches[0];
     }

--- a/src/Handle.php
+++ b/src/Handle.php
@@ -5,7 +5,7 @@ class Handle
 {
     public static function extract($str)
     {
-        preg_match_all('#\b[\d.]+/\S+\b#', $str, $matches);
+        preg_match_all('#\b[\d.]+/\S+\b#u', $str, $matches);
 
         return $matches[0];
     }

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -10,7 +10,7 @@ class Isbn
 
     private static function extractIsbnAs($str)
     {
-        preg_match_all('#(?<=10\.)97[89]\.\d{2,8}/\d{1,7}\b#', $str, $matches);
+        preg_match_all('#(?<=10\.)97[89]\.\d{2,8}/\d{1,7}\b#u', $str, $matches);
 
         return self::extractIsbn13s(
             implode(
@@ -22,14 +22,14 @@ class Isbn
 
     private static function extractIsbn13s($str)
     {
-        preg_match_all('/\b97[89]\d{10}\b/', preg_replace('/(?<=\d)[- ](?=\d)/', '', $str), $matches);
+        preg_match_all('/\b97[89]\d{10}\b/u', preg_replace('/(?<=\d)[\p{Pd}\p{Zs}](?=\d)/u', '', $str), $matches);
 
         return array_filter($matches[0], [__CLASS__, 'isValidIsbn13']);
     }
 
     private static function extractIsbn10s($str)
     {
-        preg_match_all('/\b\d{9}[\dX]\b/i', preg_replace('/(?<=\d)[- ](?=[\dX])/i', '', $str), $matches);
+        preg_match_all('/\b\d{9}[\dX]\b/ui', preg_replace('/(?<=\d)[\p{Pd}\p{Zs}](?=[\dX])/ui', '', $str), $matches);
 
         return array_map(
             [__CLASS__, 'convertIsbn10ToIsbn13'],

--- a/src/NationalClinicalTrialId.php
+++ b/src/NationalClinicalTrialId.php
@@ -5,7 +5,7 @@ class NationalClinicalTrialId
 {
     public static function extract($str)
     {
-        preg_match_all('/\bNCT\d+\b/i', $str, $matches);
+        preg_match_all('/\bNCT\d+\b/ui', $str, $matches);
 
         return array_map('strtoupper', $matches[0]);
     }

--- a/src/PubmedId.php
+++ b/src/PubmedId.php
@@ -5,7 +5,7 @@ class PubmedId
 {
     public static function extract($str)
     {
-        preg_match_all('/(?<=^|\s)0*(?!0)(\d+)(?=$|\s)/', $str, $matches);
+        preg_match_all('/(?<=^|\s)0*(?!0)(\d+)(?=$|\s)/u', $str, $matches);
 
         return $matches[1];
     }

--- a/src/RepecId.php
+++ b/src/RepecId.php
@@ -5,7 +5,7 @@ class RepecId
 {
     public static function extract($str)
     {
-        preg_match_all('/\brepec:\S+\b/i', $str, $matches);
+        preg_match_all('/\brepec:\S+\b/ui', $str, $matches);
 
         return array_map(
             function ($repecId) {

--- a/tests/AdsBibcodeTest.php
+++ b/tests/AdsBibcodeTest.php
@@ -17,4 +17,9 @@ class AdsBibcodeTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(AdsBibcode::extract('10.1097/01.ASW.0000443266.17665.19'));
     }
+
+    public function testExtractsBibcodesWithTrailingUnicodePunctuation()
+    {
+        $this->assertEquals(['2004PhRvL..93o0801M'], AdsBibcode::extract('2004PhRvL..93o0801M…'));
+    }
 }

--- a/tests/HandleTest.php
+++ b/tests/HandleTest.php
@@ -7,4 +7,9 @@ class HandleTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['10149/596901'], Handle::extract('http://hdl.handle.net/10149/596901'));
     }
+
+    public function testExtractsHandlesWithTrailingUnicodeWhitespace()
+    {
+        $this->assertEquals(['10149/596901'], Handle::extract('http://hdl.handle.net/10149/596901 '));
+    }
 }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -13,6 +13,11 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['9780805069099'], Isbn::extract('978-0-80-506909-9'));
     }
 
+    public function testExtractsIsbn13sWithUnicodeDashes()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('978–0–80–506909–9'));
+    }
+
     public function testExtractsIsbn13sWithSpaces()
     {
         $this->assertEquals(['9780805069099'], Isbn::extract('978 0 80 506909 9'));
@@ -28,9 +33,19 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['9780805069099'], Isbn::extract('978 0 80 506909 9 is great'));
     }
 
+    public function testExtractsIsbn13sWithTrailingUnicodePunctuation()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('978 0 80 506909 9…'));
+    }
+
     public function testExtractsIsbn13sOnNewLines()
     {
         $this->assertEquals(['9780805069099', '9780671879198'], Isbn::extract("978-0-80-506909-9\n978-0-67-187919-8"));
+    }
+
+    public function testExtractsIsbn13sSeparatedByUnicodeWhitespace()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('978 0 80 506909 9'));
     }
 
     public function testDoesNotExtractInvalidIsbn13s()
@@ -43,9 +58,24 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['9780805069099'], Isbn::extract('0-8050-6909-7'));
     }
 
+    public function testConvertsValidIsbn10sSeparatedByUnicodeWhitespaceToIsbn13s()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('0–8050–6909–7'));
+    }
+
+    public function testConvertsValidIsbn10sWithTrailingUnicodePunctuationToIsbn13s()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('0-8050-6909-7…'));
+    }
+
     public function testConvertsValidIsbn10sWithSpacesToIsbn13s()
     {
         $this->assertEquals(['9780805069099'], Isbn::extract('0 8050 6909 7'));
+    }
+
+    public function testConvertsValidIsbn10sWithUnicodeWhitespaceToIsbn13s()
+    {
+        $this->assertEquals(['9780805069099'], Isbn::extract('0 8050 6909 7'));
     }
 
     public function testConvertsValidIsbn10sWithSpacesAndXToIsbn13s()
@@ -66,6 +96,11 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     public function testExtractsIsbnAsFromDois()
     {
         $this->assertEquals(['9788898392315'], Isbn::extract('http://dx.doi.org/10.978.8898392/315'));
+    }
+
+    public function testExtractsIsbnAsWithTrailingUnicodePunctuation()
+    {
+        $this->assertEquals(['9788898392315'], Isbn::extract('http://dx.doi.org/10.978.8898392/315…'));
     }
 
     public function testDoesNotExtractInvalidIsbnAsFromDois()

--- a/tests/NationalClinicalTrialIdTest.php
+++ b/tests/NationalClinicalTrialIdTest.php
@@ -8,6 +8,11 @@ class NationalClinicalTrialIdTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['NCT00000106', 'NCT00000107'], NationalClinicalTrialId::extract("NCT00000106\nNCT00000107"));
     }
 
+    public function testExtractsNctIdsWithTrailingUnicodePunctuation()
+    {
+        $this->assertEquals(['NCT00000106'], NationalClinicalTrialId::extract('NCT00000106…'));
+    }
+
     public function testReturnsEmptyArrayForNoMatches()
     {
         $this->assertEmpty(NationalClinicalTrialId::extract('foobar'));

--- a/tests/OrcidIdTest.php
+++ b/tests/OrcidIdTest.php
@@ -22,4 +22,9 @@ class OrcidIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['0000-0002-1694-233X'], OrcidId::extract('0000-0002-1694-233x'));
     }
+
+    public function testExtractsOrcidsWithTrailingUnicodePunctuation()
+    {
+        $this->assertEquals(['0000-0002-0088-0058'], OrcidId::extract('orcid.org/0000-0002-0088-0058…'));
+    }
 }

--- a/tests/PubmedIdTest.php
+++ b/tests/PubmedIdTest.php
@@ -22,4 +22,9 @@ class PubmedIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(PubmedId::extract('00000000'));
     }
+
+    public function testExtractsPubmedIdsWithTrailingUnicodeWhitespace()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('123 '));
+    }
 }

--- a/tests/RepecIdTest.php
+++ b/tests/RepecIdTest.php
@@ -18,4 +18,9 @@ class RepecIdTest extends \PHPUnit_Framework_TestCase
             RepecId::extract("REPEC:wbk:wbpubs:2266\nrepec:inn:wpaper:2016-03")
         );
     }
+
+    public function testExtractsRepecIdsEndingInUnicodeWhitespace()
+    {
+        $this->assertEquals(['RePEc:wbk:wbpubs:2266'], RepecId::extract('RePEc:wbk:wbpubs:2266 '));
+    }
 }


### PR DESCRIPTION
* ISBNs now support Unicode whitespace and dashes
* RePEc IDs can be extracted from Unicode strings
* NCT IDs can be extracted from Unicode strings
* Handle IDs can be extracted from Unicode strings
* Add tests for ORCID and ADS bibcode extraction from Unicode strings