### PR TITLE
Support Unicode whitespace as a separator

### DIFF
--- a/src/Doi.php
+++ b/src/Doi.php
@@ -36,14 +36,14 @@ EOT;
 
     public static function extract($str)
     {
-        preg_match_all(self::PATTERN, strtolower($str), $matches);
+        preg_match_all(self::PATTERN, mb_strtolower($str, 'UTF-8'), $matches);
 
         return array_filter(array_map([__CLASS__, 'stripTrailingPunctuation'], $matches[0]));
     }
 
     public static function extractOne($str)
     {
-        preg_match(self::PATTERN, strtolower($str), $matches);
+        preg_match(self::PATTERN, mb_strtolower($str, 'UTF-8'), $matches);
         if (empty($matches)) {
             return;
         }

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -110,4 +110,12 @@ class DoiTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(Doi::extract('10.1130/!).",'));
     }
+
+    public function testExtractsDoisSeparatedByUnicodeWhitespace()
+    {
+        $this->assertEquals(
+            ['10.1234/foo', '10.1234/bar'],
+            Doi::extract('10.1234/foo 10.1234/bar')
+        );
+    }
 }


### PR DESCRIPTION
As we now support Unicode whitespace throughout, we have to make sure to
use multibyte-aware string functions when operating on any matches.
Without this, matches can become corrupted mid-codepoint.