### PR TITLE
Support multiple ISBNs separated by a space

### DIFF
--- a/src/ArxivId.php
+++ b/src/ArxivId.php
@@ -3,7 +3,7 @@ namespace Altmetric\Identifiers;
 
 class ArxivId
 {
-    const POST_2007_PATTERN = <<<'EOT'
+    const POST_2007_REGEXP = <<<'EOT'
 {
     (?<=^|\s|/) # Look-behind for the start of the string, whitespace or a forward slash
     (?:arXiv:)? # Optional arXiv scheme
@@ -14,7 +14,7 @@ class ArxivId
     (?=$|\s)    # Look-ahead for end of string or whitespace
 }xiu
 EOT;
-    const PRE_2007_PATTERN = <<<'EOT'
+    const PRE_2007_REGEXP = <<<'EOT'
 {
     (?<=^|\s|/)       # Look-behind for the start of the string, whitespace or a forward slash
     (?:arXiv:)?       # Optional arXiv scheme
@@ -36,14 +36,14 @@ EOT;
 
     private static function extractPost2007ArxivIds($str)
     {
-        preg_match_all(self::POST_2007_PATTERN, $str, $matches);
+        preg_match_all(self::POST_2007_REGEXP, $str, $matches);
 
         return array_map([__CLASS__, 'stripArxivScheme'], $matches[0]);
     }
 
     private static function extractPre2007ArxivIds($str)
     {
-        preg_match_all(self::PRE_2007_PATTERN, $str, $matches);
+        preg_match_all(self::PRE_2007_REGEXP, $str, $matches);
 
         return array_map([__CLASS__, 'stripArxivScheme'], $matches[0]);
     }

--- a/src/Doi.php
+++ b/src/Doi.php
@@ -3,7 +3,7 @@ namespace Altmetric\Identifiers;
 
 class Doi
 {
-    const PATTERN = <<<'EOT'
+    const REGEXP = <<<'EOT'
 {
     10 # Directory indicator (always 10)
     \.
@@ -36,14 +36,14 @@ EOT;
 
     public static function extract($str)
     {
-        preg_match_all(self::PATTERN, mb_strtolower($str, 'UTF-8'), $matches);
+        preg_match_all(self::REGEXP, mb_strtolower($str, 'UTF-8'), $matches);
 
         return array_filter(array_map([__CLASS__, 'stripTrailingPunctuation'], $matches[0]));
     }
 
     public static function extractOne($str)
     {
-        preg_match(self::PATTERN, mb_strtolower($str, 'UTF-8'), $matches);
+        preg_match(self::REGEXP, mb_strtolower($str, 'UTF-8'), $matches);
         if (empty($matches)) {
             return;
         }

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -3,7 +3,7 @@ namespace Altmetric\Identifiers;
 
 class Isbn
 {
-    const THIRTEEN_PATTERN = <<<'EOT'
+    const ISBN_13_REGEXP = <<<'EOT'
 {
     \b
     97[89]              # ISBN (GS1) Bookland prefix
@@ -16,7 +16,7 @@ class Isbn
     \b
 }xu
 EOT;
-    const TEN_PATTERN = <<<'EOT'
+    const ISBN_10_REGEXP = <<<'EOT'
 {
     \b
     (?:
@@ -27,7 +27,7 @@ EOT;
     \b
 }xu
 EOT;
-    const ISBN_A_PATTERN = <<<'EOT'
+    const ISBN_A_REGEXP = <<<'EOT'
 {
     (?<=10\.)   # Directory indicator (always 10)
     97[89]\.    # ISBN (GS1) Bookland prefix
@@ -45,7 +45,7 @@ EOT;
 
     private static function extractIsbnAs($str)
     {
-        preg_match_all(self::ISBN_A_PATTERN, $str, $matches);
+        preg_match_all(self::ISBN_A_REGEXP, $str, $matches);
 
         return self::extractIsbn13s(
             implode(
@@ -57,7 +57,7 @@ EOT;
 
     private static function extractIsbn13s($str)
     {
-        preg_match_all(self::THIRTEEN_PATTERN, $str, $matches);
+        preg_match_all(self::ISBN_13_REGEXP, $str, $matches);
 
         return array_filter(
             array_map([__CLASS__, 'stripHyphenation'], $matches[0]),
@@ -67,7 +67,7 @@ EOT;
 
     private static function extractIsbn10s($str)
     {
-        preg_match_all(self::TEN_PATTERN, $str, $matches);
+        preg_match_all(self::ISBN_10_REGEXP, $str, $matches);
 
         return array_map(
             [__CLASS__, 'convertIsbn10ToIsbn13'],

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -8,7 +8,7 @@ class Uri
      * Thanks to Jeff Roberson's "Regular Expression URI Validation",
      * http://jmrware.com/articles/2009/uri_regexp/URI_regex.html#uri-40
      */
-    const PATTERN = <<<'EOF'
+    const REGEXP = <<<'EOF'
 #
     (
         [A-Za-z][A-Za-z0-9+\-.]* :
@@ -54,7 +54,7 @@ EOF;
 
     public static function extract($str)
     {
-        preg_match_all(self::PATTERN, $str, $matches);
+        preg_match_all(self::REGEXP, $str, $matches);
 
         return $matches[0];
     }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -8,6 +8,11 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['9780805069099', '9780671879198'], Isbn::extract("ISBN: 9780805069099\nISBN: 9780671879198"));
     }
 
+    public function testExtractsIsbn13sSeparatedByASpace()
+    {
+        $this->assertEquals(['9780805069099', '9780671879198'], Isbn::extract('9780805069099 9780671879198'));
+    }
+
     public function testExtractsIsbn13sWithDashes()
     {
         $this->assertEquals(['9780805069099'], Isbn::extract('978-0-80-506909-9'));
@@ -41,6 +46,11 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     public function testExtractsIsbn13sOnNewLines()
     {
         $this->assertEquals(['9780805069099', '9780671879198'], Isbn::extract("978-0-80-506909-9\n978-0-67-187919-8"));
+    }
+
+    public function testExtractsHyphenatedIsbn13sSeparatedByASpace()
+    {
+        $this->assertEquals(['9780805069099', '9780671879198'], Isbn::extract("978-0-80-506909-9 978-0-67-187919-8"));
     }
 
     public function testExtractsIsbn13sSeparatedByUnicodeWhitespace()


### PR DESCRIPTION
GitHub: https://github.com/altmetric/php-identifiers/issues/12

Rather than handling ISBNs with hyphenation by removing all hyphenation (including spaces) before extraction, encode possible hyphenation points into extraction itself.

As the full hyphenation rules for ISBNs are complicated and require tables of publisher-specific rules (as each group within the ISBN can be of variable length), permit hyphenation between any digits after the Bookland prefix and then strip it before validation.