### PR TITLE
Don't deduplicate identifiers and don't extract ISBN-10s from ISBN-13s

### DIFF
--- a/src/ArxivId.php
+++ b/src/ArxivId.php
@@ -31,7 +31,7 @@ EOT;
 
     public static function extract($str)
     {
-        return self::extractPre2007ArxivIds($str) + self::extractPost2007ArxivIds($str);
+        return array_merge(self::extractPre2007ArxivIds($str), self::extractPost2007ArxivIds($str));
     }
 
     private static function extractPost2007ArxivIds($str)

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -40,7 +40,7 @@ EOT;
 
     public static function extract($str)
     {
-        return self::extractIsbnAs($str) + self::extractIsbn13s($str) + self::extractIsbn10s($str);
+        return array_merge(self::extractIsbnAs($str), self::extractIsbn13s($str), self::extractIsbn10s($str));
     }
 
     private static function extractIsbnAs($str)

--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -18,6 +18,10 @@ class Isbn
 EOT;
     const ISBN_10_REGEXP = <<<'EOT'
 {
+    (?<!                # Don't match a hyphenated or spaced ISBN-13
+        97[89]
+        [\p{Pd}\p{Zs}]
+    )
     \b
     (?:
         \d              # Digit

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -122,4 +122,14 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['9780309570794', '9780309570794'], Isbn::extract('0309570794 9780309570794'));
     }
+
+    public function testDoesNotExtractIsbn10sFromHyphenatedIsbn13s()
+    {
+        $this->assertEquals(['9780309570794'], Isbn::extract('978-0-309-57079-4'));
+    }
+
+    public function testDoesNotExtractIsbn10sFromSpaceSeparatedIsbn13s()
+    {
+        $this->assertEquals(['9780309570794'], Isbn::extract('978 0 309 57079 4'));
+    }
 }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -117,4 +117,9 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(Isbn::extract('http://dx.doi.org/10.978.8898392/316'));
     }
+
+    public function testDoesNotDeduplicateIsbns()
+    {
+        $this->assertEquals(['9780309570794', '9780309570794'], Isbn::extract('0309570794 9780309570794'));
+    }
 }


### PR DESCRIPTION
As a side-effect of using the + array operator, we were returning a unique set of identifiers when extracting arXiv IDs and ISBNs. For consistency with other versions of this library, we should perform no such deduplication and instead return each result as it is found.

The improved support for hyphenated ISBNs has accidentally started extracting ISBN-10s from ISBN-13s when they are substrings of one another (typically the check digit changes but there are some ISBNs with check digits that do not change when converting).

As this means we'll start returning duplicate ISBNs for any ISBN that has this property, explicitly prevent extracting ISBN-10s from valid ISBN-13s.