### PR TITLE
Extract PubMed IDs from PubMed URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ Return an array of ORCID identifiers from a given string. Will return an empty a
 ```php
 use Altmetric\Identifiers\PubmedId;
 
-$pubmedIds = PubmedId::extract("23193287\n14599470");
+$pubmedIds = PubmedId::extract("23193287\n14599470\nhttps://www.ncbi.nlm.nih.gov/pubmed/123");
+//=> ['23193287', '14599470', '123']
 ```
 
 Return an array of PubMed IDs from a given string. Will return an empty array if no matches are found.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Return an array of ORCID identifiers from a given string. Will return an empty a
 ```php
 use Altmetric\Identifiers\PubmedId;
 
-$pubmedIds = PubmedId::extract("23193287\n14599470\nhttps://www.ncbi.nlm.nih.gov/pubmed/123");
-//=> ['23193287', '14599470', '123']
+$pubmedIds = PubmedId::extract("23193287\n14599470\nhttps://www.ncbi.nlm.nih.gov/pubmed/123\npmid:456\ninfo:pmid/789");
+//=> ['23193287', '14599470', '123', '456', '789']
 ```
 
 Return an array of PubMed IDs from a given string. Will return an empty array if no matches are found.

--- a/src/PubmedId.php
+++ b/src/PubmedId.php
@@ -3,9 +3,38 @@ namespace Altmetric\Identifiers;
 
 class PubmedId
 {
+    const REGEXP = <<<'EOT'
+{
+    (?<=
+        # Valid prefixes
+        ^                               # Start of the input
+        |
+        \s                              # Whitespace
+        |
+        ncbi\.nlm\.nih\.gov/pubmed/     # PubMed record page
+        |
+        ncbi\.nlm\.nih\.gov/m/pubmed/   # Mobile PubMed record page
+    )
+    0*          # Zero padding
+    (?!0)(\d+)  # Number (not starting with zero)
+    (?=
+        # Valid suffixes
+        $   # End of string
+        |
+        \s  # Whitespace
+        |
+        /   # Trailing slash
+        |
+        \?  # Query string
+        |
+        \#  # Fragment
+    )
+}xu
+EOT;
+
     public static function extract($str)
     {
-        preg_match_all('/(?<=^|\s)0*(?!0)(\d+)(?=$|\s)/u', $str, $matches);
+        preg_match_all(self::REGEXP, $str, $matches);
 
         return $matches[1];
     }

--- a/src/PubmedId.php
+++ b/src/PubmedId.php
@@ -14,6 +14,10 @@ class PubmedId
         ncbi\.nlm\.nih\.gov/pubmed/     # PubMed record page
         |
         ncbi\.nlm\.nih\.gov/m/pubmed/   # Mobile PubMed record page
+        |
+        pmid:                           # URI with pmid scheme
+        |
+        info:pmid/                      # URI with PubMed info scheme
     )
     0*          # Zero padding
     (?!0)(\d+)  # Number (not starting with zero)

--- a/src/PubmedId.php
+++ b/src/PubmedId.php
@@ -3,42 +3,56 @@ namespace Altmetric\Identifiers;
 
 class PubmedId
 {
-    const REGEXP = <<<'EOT'
+    const ID_REGEXP = <<<'EOT'
 {
-    (?<=
-        # Valid prefixes
-        ^                               # Start of the input
-        |
-        \s                              # Whitespace
-        |
-        ncbi\.nlm\.nih\.gov/pubmed/     # PubMed record page
-        |
-        ncbi\.nlm\.nih\.gov/m/pubmed/   # Mobile PubMed record page
-        |
-        pmid:                           # URI with pmid scheme
-        |
-        info:pmid/                      # URI with PubMed info scheme
-    )
-    0*          # Zero padding
-    (?!0)(\d+)  # Number (not starting with zero)
-    (?=
-        # Valid suffixes
-        $   # End of string
-        |
-        \s  # Whitespace
-        |
-        /   # Trailing slash
-        |
-        \?  # Query string
-        |
-        \#  # Fragment
-    )
+        (?<=
+            # Valid prefixes
+            ^   # Start of the input
+            |
+            \s  # Whitespace
+        )
+        0*          # Zero padding
+        (?!0)(\d+)  # Number that does not start with zero
+        (?=
+            # Valid suffixes
+            $   # End of the input
+            |
+            \s  # Whitespace
+        )
+}xu
+EOT;
+    const URI_REGEXP = <<<'EOT'
+{
+        (?<=
+            # Valid prefixes
+            ncbi\.nlm\.nih\.gov/pubmed/
+            |
+            ncbi\.nlm\.nih\.gov/m/pubmed/
+            |
+            pmid:
+            |
+            info:pmid/
+        )
+        0*          # Zero padding
+        (?!0)(\d+)  # Number that does not start with zero
 }xu
 EOT;
 
     public static function extract($str)
     {
-        preg_match_all(self::REGEXP, $str, $matches);
+        return array_merge(self::extractPubmedIds($str), self::extractPubmedUris($str));
+    }
+
+    private static function extractPubmedIds($str)
+    {
+        preg_match_all(self::ID_REGEXP, $str, $matches);
+
+        return $matches[1];
+    }
+
+    private static function extractPubmedUris($str)
+    {
+        preg_match_all(self::URI_REGEXP, $str, $matches);
 
         return $matches[1];
     }

--- a/tests/AdsBibcodeTest.php
+++ b/tests/AdsBibcodeTest.php
@@ -22,4 +22,9 @@ class AdsBibcodeTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['2004PhRvL..93o0801M'], AdsBibcode::extract('2004PhRvL..93o0801M…'));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(AdsBibcode::extract(null));
+    }
 }

--- a/tests/ArxivIdTest.php
+++ b/tests/ArxivIdTest.php
@@ -42,4 +42,9 @@ class ArxivIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['math/0309136'], ArxivId::extract('https://arxiv.org/abs/math/0309136'));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(ArxivId::extract(null));
+    }
 }

--- a/tests/DoiTest.php
+++ b/tests/DoiTest.php
@@ -118,4 +118,9 @@ class DoiTest extends \PHPUnit_Framework_TestCase
             Doi::extract('10.1234/foo 10.1234/bar')
         );
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(Doi::extract(null));
+    }
 }

--- a/tests/HandleTest.php
+++ b/tests/HandleTest.php
@@ -12,4 +12,9 @@ class HandleTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['10149/596901'], Handle::extract('http://hdl.handle.net/10149/596901 '));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(Handle::extract(null));
+    }
 }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -132,4 +132,9 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['9780309570794'], Isbn::extract('978 0 309 57079 4'));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(Isbn::extract(null));
+    }
 }

--- a/tests/NationalClinicalTrialIdTest.php
+++ b/tests/NationalClinicalTrialIdTest.php
@@ -22,4 +22,9 @@ class NationalClinicalTrialIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['NCT00000106', 'NCT00000107'], NationalClinicalTrialId::extract("nct00000106\nnCt00000107"));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(NationalClinicalTrialId::extract(null));
+    }
 }

--- a/tests/OrcidIdTest.php
+++ b/tests/OrcidIdTest.php
@@ -27,4 +27,9 @@ class OrcidIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['0000-0002-0088-0058'], OrcidId::extract('orcid.org/0000-0002-0088-0058…'));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(OrcidId::extract(null));
+    }
 }

--- a/tests/PubmedIdTest.php
+++ b/tests/PubmedIdTest.php
@@ -32,4 +32,34 @@ class PubmedIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(PubmedId::extract(null));
     }
+
+    public function testExtractsPubmedIdsFromPubmedUrls()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/pubmed/123'));
+    }
+
+    public function testExtractsPubmedIdsFromPubmedUrlsWithTrailingSlashes()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/pubmed/123/'));
+    }
+
+    public function testExtractsPubmedIdsFromPubmedUrlsWithQueryStrings()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/pubmed/123?foo=bar'));
+    }
+
+    public function testExtractsPubmedIdsFromPubmedUrlsWithFragments()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/pubmed/123#foo'));
+    }
+
+    public function testExtractsPubmedIdsFromMobilePubmedUrls()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/m/pubmed/123'));
+    }
+
+    public function testStripsLeadingZeroesFromPubmedUrls()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/pubmed/000123'));
+    }
 }

--- a/tests/PubmedIdTest.php
+++ b/tests/PubmedIdTest.php
@@ -27,4 +27,9 @@ class PubmedIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['123'], PubmedId::extract('123 '));
     }
+
+    public function testReturnsAnEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(PubmedId::extract(null));
+    }
 }

--- a/tests/PubmedIdTest.php
+++ b/tests/PubmedIdTest.php
@@ -82,4 +82,9 @@ class PubmedIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['123'], PubmedId::extract('info:pmid/000123'));
     }
+
+    public function testDoesNotExtractNumbersEndingInUrlCharacters()
+    {
+        $this->assertEmpty(PubmedId::extract('123#'));
+    }
 }

--- a/tests/PubmedIdTest.php
+++ b/tests/PubmedIdTest.php
@@ -62,4 +62,24 @@ class PubmedIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['123'], PubmedId::extract('https://www.ncbi.nlm.nih.gov/pubmed/000123'));
     }
+
+    public function testExtractsPubmedIdsWithPmidScheme()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('pmid:123'));
+    }
+
+    public function testStripsLeadingZeroesFromPmidScheme()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('pmid:000123'));
+    }
+
+    public function testExtractsPubmedIdsWithInfoPmidScheme()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('info:pmid/123'));
+    }
+
+    public function testStripsLeadingZeroesFromInfoPmidScheme()
+    {
+        $this->assertEquals(['123'], PubmedId::extract('info:pmid/000123'));
+    }
 }

--- a/tests/RepecIdTest.php
+++ b/tests/RepecIdTest.php
@@ -23,4 +23,9 @@ class RepecIdTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['RePEc:wbk:wbpubs:2266'], RepecId::extract('RePEc:wbk:wbpubs:2266 '));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(RepecId::extract(null));
+    }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -47,4 +47,9 @@ class UriTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(Uri::extract('Nothing to.see here.'));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(Uri::extract(null));
+    }
 }

--- a/tests/UrnTest.php
+++ b/tests/UrnTest.php
@@ -47,4 +47,9 @@ class UrnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(['urn:mutton:chops.'], Urn::extract('urn:mutton:chops.'));
     }
+
+    public function testReturnsEmptyArrayWhenGivenNull()
+    {
+        $this->assertEmpty(Urn::extract(null));
+    }
 }


### PR DESCRIPTION
Support the extraction of PubMed IDs from PubMed record page URLs such as https://www.ncbi.nlm.nih.gov/pubmed/123 and https://www.ncbi.nlm.nih.gov/m/pubmed/123/

As with other PubMed IDs, strip any leading zeroes from these IDs (e.g.  https://www.ncbi.nlm.nih.gov/m/pubmed/000123/ will return 123, not 000123).