### PR TITLE
Be stricter with valid ISBN hyphenation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,9 @@
     "require-dev": {
         "phpunit/phpunit": "^4.8"
     },
+    "suggest": {
+        "ext-mbstring": "Needed for multibyte string support (alternatively, require symfony/polyfill-mbstring)"
+    },
     "autoload": {
         "psr-4": { "Altmetric\\Identifiers\\": "src/" }
     }

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -137,4 +137,34 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(Isbn::extract(null));
     }
+
+    public function testDoesNotExtractIsbn13sFromStringsWithInconsistentHyphenation()
+    {
+        $this->assertEmpty(Isbn::extract('978-0 80-506909 9'));
+    }
+
+    public function testDoesNotExtractIsbn10sFromStringsWithInconsistentHyphenation()
+    {
+        $this->assertEmpty(Isbn::extract('0-8050 6909-7'));
+    }
+
+    public function testDoesNotExtractIsbn13sWithMoreThanFiveGroups()
+    {
+        $this->assertEmpty(Isbn::extract('978-0-80-506-909-9'));
+    }
+
+    public function testDoesNotExtractIsbn13sWithLessThanFiveGroups()
+    {
+        $this->assertEmpty(Isbn::extract('978-0-80506909-9'));
+    }
+
+    public function testDoesNotExtractIsbn10sWithMoreThanFourGroups()
+    {
+        $this->assertEmpty(Isbn::extract('0-8050-69-09-7'));
+    }
+
+    public function testDoesNotExtractIsbn10sWithLessThanFourGroups()
+    {
+        $this->assertEmpty(Isbn::extract('0-80506909-7'));
+    }
 }


### PR DESCRIPTION
Only permit consistent hyphenation within ISBNs (e.g. only spaces or only dashes) and ISBNs with the appropriate number of groups, i.e. 5 groups for ISBN-13s and 4 groups for ISBN-10s.