### PR TITLE
Support variable width ISBN registration group IDs

### DIFF
--- a/src/Isbn.php
+++ b/src/Isbn.php
@@ -26,12 +26,12 @@ EOT;
     )
     \b
     (
-        \d                  # Digit
+        \d{1,5}             # Registration group identifier
         ([\p{Pd}\p{Zs}])?   # Optional hyphenation
         (?:
             \d              # Digit
             \2?             # Optional hyphenation
-        ){8}
+        ){4,8}
         [\dX]               # Check digit
     )
     \b

--- a/tests/IsbnTest.php
+++ b/tests/IsbnTest.php
@@ -167,4 +167,12 @@ class IsbnTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEmpty(Isbn::extract('0-80506909-7'));
     }
+
+    public function testExtractsIsbn10sWithVariableWidthRegistrationGroupIdentifiers()
+    {
+        $this->assertEquals(
+            ['9789992158104', '9789971502102', '9789604250592', '9788090273412'],
+            Isbn::extract('99921-58-10-7 9971-5-0210-0 960-425-059-0 80-902734-1-6')
+        );
+    }
 }


### PR DESCRIPTION
As part of tightening up our hyphenation validation, we lost support for ISBN 10s with a registration group identifier with more than one digit.  Restore support for these by permitting any registration group identifier from 1 to 5 digits.